### PR TITLE
Add 'comments' field on 'Post' type

### DIFF
--- a/src/appsyncrdslambdasampletemplate.yaml
+++ b/src/appsyncrdslambdasampletemplate.yaml
@@ -155,6 +155,7 @@ Resources:
           author: String!
           content: String!
           views: Int
+          comments: [Comment]
         }
 
         type Query {
@@ -484,6 +485,28 @@ Resources:
         }
       ResponseMappingTemplate: |
         $util.toJson($context.result)
+
+  AppSyncRDSResolverResolveCommentsOnPost:
+    Type: "AWS::AppSync::Resolver"
+    DependsOn: AppSyncRDSAPISchema
+    Properties:
+      ApiId: !GetAtt AppSyncRDSAPI.ApiId
+      TypeName: "Post"
+      FieldName: "comments"
+      DataSourceName: !GetAtt AppSyncRDSLambdaDataSource.Name
+      RequestMappingTemplate: |
+        {
+            "version" : "2017-02-28",
+            "operation": "Invoke",
+            "payload": {
+              "sql":"SELECT * FROM posts WHERE id = :POST_ID",
+              "variableMapping": {
+                ":POST_ID" : "$context.source.id"
+              }
+            }
+        }
+      ResponseMappingTemplate: |
+        $util.toJson($context.result[0])
 
   #Lambda and access role
   AppSyncRDSLambdaExecutionRole:


### PR DESCRIPTION
*Description of changes:*
Adds ability to resolve comments directly from Post type. This further extends example of graphQL potential of modular queries and allows to get all your post and comments in one query rather than in two (first query for posts and then for comments using posts ids)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
