### PR TITLE
tiny typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,7 +201,7 @@ subscription AddedCommentByAuthor{
   }
 }
 ```
-Note: subscriptions are long-running processes that won't show anything until a mutation runs. To do this, you'll need two tabs in the AppSync console - one to execure the subscription and then a second to execute the mutation. Additionally, AppSync requires that filters in subscriptions be in the response of the mutation, so createComment must return author to do this.
+Note: subscriptions are long-running processes that won't show anything until a mutation runs. To do this, you'll need two tabs in the AppSync console - one to execute the subscription and then a second to execute the mutation. Additionally, AppSync requires that filters in subscriptions be in the response of the mutation, so createComment must return author to do this.
 
 
 ## License Summary


### PR DESCRIPTION
execure changed to execute

typo fixed


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
