### PR TITLE
Upgrade deprecated runtime nodejs8.10

### DIFF
--- a/src/appsyncrdslambdasampletemplate.yaml
+++ b/src/appsyncrdslambdasampletemplate.yaml
@@ -232,7 +232,7 @@ Resources:
         S3Key: samples/rds-over-lambda-sample/AppSyncRDSLambdaSampleCode.zip
       Handler: index.handler
       MemorySize: 256
-      Runtime: "nodejs8.10"
+      Runtime: "nodejs10.x"
       Timeout: "60"
       ReservedConcurrentExecutions: 100
       Tags:


### PR DESCRIPTION
CloudFormation templates in aws-appsync-rds-aurora-sample have been found to include a [deprecated Lambda function runtime](https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html) (nodejs8.10). The affected templates have been updated to a supported runtime (nodejs10.x).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.