### PR TITLE
InvalidParameterValueException

### DIFF
--- a/src/appsyncrdslambdasampletemplate.yaml
+++ b/src/appsyncrdslambdasampletemplate.yaml
@@ -232,7 +232,7 @@ Resources:
         S3Key: samples/rds-over-lambda-sample/AppSyncRDSLambdaSampleCode.zip
       Handler: index.handler
       MemorySize: 256
-      Runtime: "nodejs8.10"
+      Runtime: "nodejs12.x"
       Timeout: "60"
       ReservedConcurrentExecutions: 100
       Tags:


### PR DESCRIPTION
The runtime parameter of nodejs8.10 is no longer supported for creating or updating AWS Lambda functions. We recommend you use the new runtime (nodejs12.x) while creating or updating functions.